### PR TITLE
Add aot compilation for Quartz to be able to view classes

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -17,7 +17,9 @@
   :profiles {:dev {:resource-paths ["test-resources"]
                    :dependencies   [[ch.qos.logback/logback-classic "1.2.11"]
                                     [org.clojure/core.async "1.5.648"]
-                                    [clj-kondo "2022.09.08"]]}}
+                                    [clj-kondo "2022.09.08"]]}
+             :uberjar {:aot [cronut] 
+                       :dependencies [[org.slf4j/slf4j-api "2.0.17"]]}}
 
   :deploy-repositories [["releases" {:url "https://clojars.org/repo/" :creds :gpg}]]
 


### PR DESCRIPTION
**Problem**
When using Quartz with a JDBC job store (org.quartz.jobStore.class = org.quartz.impl.jdbcjobstore.JobStoreTX), job definitions are persisted to the database. However, when Quartz attempts to deserialize a job class such as cronut.SerialProxyJob or cronut.ProxyJob, it fails with a ClassNotFoundException.

This happens because the Clojure classes are not Ahead-of-Time (AOT) compiled—there are no .class files available for the Quartz classloader to load at runtime.

**Solution**
AOT-compiling the library and building it as an uberjar ensures that the required Clojure-defined job classes are available as .class files, allowing Quartz to successfully deserialize and execute them.

**Error excerpt**

```
2025-06-10T07:57:12.886Z 89550b78789f ERROR [org.quartz.impl.jdbcjobstore.JobStoreTX:2867] - Error retrieving job, setting trigger state to ERROR.
java.lang.ClassNotFoundException: cronut.ProxyJob
    at org.quartz.simpl.CascadingClassLoadHelper.loadClass(CascadingClassLoadHelper.java:138)
    at org.quartz.impl.jdbcjobstore.StdJDBCDelegate.selectJobDetail(StdJDBCDelegate.java:852)
    ...
Caused by: org.quartz.JobPersistenceException: Couldn't retrieve job because a required class was not found: cronut.ProxyJob
```